### PR TITLE
Link updates to new XAD documentation website

### DIFF
--- a/extensions.shtml
+++ b/extensions.shtml
@@ -23,12 +23,12 @@ and OpenOffice/LibreOffice Calc.</p>
 <h3 class="center">Adjoint Algorithmic Differentiation (AAD) support</h3>
 
 <p>Adjoint algorithmic differentiation (AAD) can be enabled in QuantLib
-using the open-source <a href="https://github.com/xcelerit/XAD">XAD
+using the open-source <a href="https://auto-differentiation.github.io">XAD
 AAD tool</a> and
-<a href="https://github.com/xcelerit/qlxad">an XAD/QuantLib
+<a href="https://auto-differentiation.github.io/quantlib/">an XAD/QuantLib
 integration module</a>.  QuantLib's AAD-compatibility is actively
 maintained
-via <a href="https://github.com/xcelerit/qlxad/actions/workflows/ci.yaml">automated
+via <a href="https://github.com/auto-differentiation/qlxad/actions/workflows/ci.yaml">automated
 CI/CD checks</a>, running daily against QuantLib's master branch.
 </p>
 

--- a/install/cmake.shtml
+++ b/install/cmake.shtml
@@ -407,8 +407,9 @@ cmake -G Ninja ... # (add other options as before)
 
 <p>
     An example on how this extension hook can be used is in the 
-    <a href="https://github.com/xcelerit/qlxad">qlxad repository</a>,
+    <a href="https://github.com/auto-differentiation/qlxad">qlxad repository</a>,
     which integrates the open source
-    <a href="https://github.com/xcelerit/XAD">XAD AAD tool</a>
-    into the QuantLib build.
+    <a href="https://auto-differentiation.github.io">XAD AAD tool</a>
+    into the <a href="https://auto-differentiation.github.io/quantlib/">QuantLib build</a>.
+    
 </p>


### PR DESCRIPTION
This PR updates links on [quantlib.org](https://www.quantlib.org/) to the new [XAD documentation site](https://auto-differentiation.github.io/)