### PR TITLE
Add Sonoma instructions

### DIFF
--- a/install/macosx-python.shtml
+++ b/install/macosx-python.shtml
@@ -47,8 +47,8 @@ few required compilation flags.</p>
 <p><strong>On Mac OS X 10.15 (Sonoma) and later,</strong>
 <pre>
   cd QuantLib-SWIG-1.29/Python
-  export CXXFLAGS='-O2 -stdlib=libc++ -stdlib=libc++ -I<boost home>/include/ -mmacosx-version-min=10.9'
-  export LDFLAGS='-stdlib=libc++ -mmacosx-version-min=10.9'
+  export CXXFLAGS="`quantlib-config --cflags` -O2 -std=c++14 -stdlib=libc++ -mmacosx-version-min=10.9"
+  export LDFLAGS="`quantlib-config --libs` -stdlib=libc++ -mmacosx-version-min=10.9"
   python3 setup.py build
 </pre>
 </p>

--- a/install/macosx-python.shtml
+++ b/install/macosx-python.shtml
@@ -44,27 +44,19 @@ also need to add <tt>-std=c++11</tt> to <tt>CXXFLAGS</tt>.  Again,
 make sure that you can execute <tt>quantlib-config</tt> from the
 terminal, since the <tt>setup.py</tt> build will call it to retrieve a
 few required compilation flags.</p>
-<p><strong>On Mac OS X 10.15 (Sonoma) and later,</strong>
-<pre>
-  cd QuantLib-SWIG-1.29/Python
-  export CXXFLAGS="`quantlib-config --cflags` -O2 -std=c++14 -stdlib=libc++ -mmacosx-version-min=10.9"
-  export LDFLAGS="`quantlib-config --libs` -stdlib=libc++ -mmacosx-version-min=10.9"
-  python3 setup.py build
-</pre>
-</p>
 <p><strong>On Mac OS X 10.11 (El Capitan) and later,</strong>
 <pre>
   cd QuantLib-SWIG-1.29/Python
-  export CXXFLAGS='-O2 -stdlib=libc++ -mmacosx-version-min=10.9'
-  export LDFLAGS='-stdlib=libc++ -mmacosx-version-min=10.9'
+  export CXXFLAGS='`quantlib-config --cflags` -O2 -std=c++14 -stdlib=libc++ -mmacosx-version-min=10.9'
+  export LDFLAGS='`quantlib-config --libs` -stdlib=libc++ -mmacosx-version-min=10.9'
   python3 setup.py build
 </pre>
 </p>
 <p><strong>On Mac OS X 10.9 (Mavericks) and 10.10 (Yosemite),</strong>
 <pre>
   cd QuantLib-SWIG-1.29/Python
-  export CXXFLAGS='-O2 -stdlib=libstdc++ -mmacosx-version-min=10.6'
-  export LDFLAGS='-stdlib=libstdc++ -mmacosx-version-min=10.6'
+  export CXXFLAGS="`quantlib-config --cflags` -O2 -std=c++14 -stdlib=libc++ -mmacosx-version-min=10.6"
+  export LDFLAGS="`quantlib-config --libs` -stdlib=libc++ -mmacosx-version-min=10.6"
   python3 setup.py build
 </pre>
 </p>

--- a/install/macosx-python.shtml
+++ b/install/macosx-python.shtml
@@ -44,6 +44,14 @@ also need to add <tt>-std=c++11</tt> to <tt>CXXFLAGS</tt>.  Again,
 make sure that you can execute <tt>quantlib-config</tt> from the
 terminal, since the <tt>setup.py</tt> build will call it to retrieve a
 few required compilation flags.</p>
+<p><strong>On Mac OS X 10.15 (Sonoma) and later,</strong>
+<pre>
+  cd QuantLib-SWIG-1.29/Python
+  export CXXFLAGS='-O2 -stdlib=libc++ -stdlib=libc++ -I<boost home>/include/ -mmacosx-version-min=10.9'
+  export LDFLAGS='-stdlib=libc++ -mmacosx-version-min=10.9'
+  python3 setup.py build
+</pre>
+</p>
 <p><strong>On Mac OS X 10.11 (El Capitan) and later,</strong>
 <pre>
   cd QuantLib-SWIG-1.29/Python


### PR DESCRIPTION
To build the Python module on MacOS Sonoma 14.5 the following CXXFLAGS where needed added 
1. -std=c++14
2. -I/opt/homebrew/Cellar/boost/1.85.0/include/

```bash
export CXXFLAGS="-O2 -std=c++14 -stdlib=libc++ -mmacosx-version-min=10.9 -I/opt/homebrew/Cellar/boost/1.85.0/include/"
```

In addition to have the freshly build QuantLib utilized I had to manually add the library path to prevent libQuantLib.1.dylib' (no such file. Potentially this could be avoided.
export DYLD_LIBRARY_PATH=/usr/local/lib:$DYLD_LIBRARY_PATH

If there is a better way I'm all ears.